### PR TITLE
Fix cross-platform filepaths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode-test/
 *.vsix
 .env
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,160 +1,160 @@
 {
-    "name": "vscode-animalese",
-    "displayName": "VSCode Animalese",
-    "description": "Makes animal crossing sounds whenever you type. Highly customizable with very low latency, written with a Node.js adaptation of the Web Audio API.",
-    "version": "0.2.1",
-    "publisher": "AidanHsiao",
-    "engines": {
-        "vscode": "^1.101.0"
-    },
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "onStartupFinished"
-    ],
-    "main": "./dist/extension.js",
-    "contributes": {
-        "commands": [
-            {
-                "command": "vscode-animalese.enable",
-                "title": "vscode-animalese: Enable Animalese Sounds"
-            },
-            {
-                "command": "vscode-animalese.disable",
-                "title": "vscode-animalese: Disable Animalese Sounds"
-            },
-            {
-                "command": "vscode-animalese.toggle",
-                "title": "vscode-animalese: Toggle Animalese Sounds"
-            },
-            {
-                "command": "vscode-animalese.setVolume",
-                "title": "vscode-animalese: Set Animalese Volume"
-            },
-            {
-                "command": "vscode-animalese.setVoice",
-                "title": "vscode-animalese: Set Animalese Voice"
-            }
-        ],
-        "configuration": {
-            "title": "VSCode Animalese",
-            "type": "object",
-            "properties": {
-                "vscode-animalese.volume": {
-                    "type": "integer",
-                    "default": 50,
-                    "description": "This value dictates, in percentage, how loud the animalese sounds should be.",
-                    "order": 1,
-                    "minimum": 0,
-                    "maximum": 100
-                },
-                "vscode-animalese.voice": {
-                    "type": "string",
-                    "enum": [
-                        "Female Voice 1 (Sweet)",
-                        "Female Voice 2 (Peppy)",
-                        "Female Voice 3 (Big Sister)",
-                        "Female Voice 4 (Snooty)",
-                        "Male Voice 1 (Jock)",
-                        "Male Voice 2 (Lazy)",
-                        "Male Voice 3 (Smug)",
-                        "Male Voice 4 (Cranky)"
-                    ],
-                    "default": "Female Voice 1 (Sweet)",
-                    "description": "Determines the voice that will be talking. This setting only applies to alphanumerical characters.",
-                    "order": 2
-                },
-                "vscode-animalese.specialPunctuation": {
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Overrides the default sounds for the keys `!`, `?`, and `Enter`.",
-                    "order": 3
-                },
-                "vscode-animalese.soundOverride": {
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": "Replace **ALL** sounds with an absolute path to the given sound file.",
-                    "order": 4
-                },
-                "vscode-animalese.intonation.louderUppercase": {
-                    "type": "number",
-                    "default": 20,
-                    "description": "Indicates the percentage increase that uppercase letters will make, over lowercase letters. For example, if this value is 25, the volume of any uppercase letter will be 125%.",
-                    "minimum": 0
-                },
-                "vscode-animalese.intonation.falloffTime": {
-                    "type": "number",
-                    "default": 0.5,
-                    "description": "When a key is pressed, the audio slowly fades out over the course of the track. This value determines how many seconds it takes before the audio fully fades out.",
-                    "minimum": 0
-                },
-                "vscode-animalese.intonation.pitchVariation": {
-                    "type": "integer",
-                    "default": 100,
-                    "markdownDescription": "For any key except for vocal keys, randomly shift the pitch of the audio up or down by, at most, the amount of [cents](https://en.wikipedia.org/wiki/Cent_%28music%29) given.",
-                    "minimum": 0
-                },
-                "vscode-animalese.intonation.switchToExponentialFalloff": {
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "If checked, the audio volume will fall off at an exponential rate instead of a linear one."
-                }
-            }
-        }
-    },
-    "scripts": {
-        "vscode:prepublish": "npm run package",
-        "compile": "webpack",
-        "watch": "webpack --watch",
-        "package": "webpack --mode production --devtool hidden-source-map",
-        "compile-tests": "tsc -p . --outDir out",
-        "watch-tests": "tsc -p . -w --outDir out",
-        "lint": "eslint src",
-        "test": "jest"
-    },
-    "devDependencies": {
-        "@types/jest": "^29.5.14",
-        "@types/mocha": "^10.0.10",
-        "@types/node": "20.x",
-        "@types/vscode": "^1.101.0",
-        "@typescript-eslint/eslint-plugin": "^8.31.1",
-        "@typescript-eslint/parser": "^8.31.1",
-        "@vscode/test-cli": "^0.0.10",
-        "@vscode/test-electron": "^2.5.2",
-        "eslint": "^9.25.1",
-        "jest": "^29.7.0",
-        "node-loader": "^2.1.0",
-        "ts-jest": "^29.4.0",
-        "ts-loader": "^9.5.2",
-        "typescript": "^5.8.3",
-        "webpack": "^5.99.7",
-        "webpack-cli": "^6.0.1"
-    },
-    "dependencies": {
-        "node-web-audio-api": "^1.0.4"
-    },
-    "icon": "./public/icon.png",
-    "galleryBanner": {
-        "color": "#e0d0b4",
-        "theme": "light"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/ESV-Sweetplum/vscode-animalese.git"
-    },
-    "homepage": "https://github.com/ESV-Sweetplum/vscode-animalese/blob/main/README.md",
-    "license": "https://github.com/ESV-Sweetplum/vscode-animalese/blob/main/LICENSE",
-    "keywords": [
-        "Animalese",
-        "Animal Crossing",
-        "Tom Nook",
-        "Isabelle",
-        "Typing Sound",
-        "Sound",
-        "Audio",
-        "Keypress Audio",
-        "Keypress Sounds",
-        "Typing Sounds"
-    ]
+	"name": "vscode-animalese",
+	"displayName": "VSCode Animalese",
+	"description": "Makes animal crossing sounds whenever you type. Highly customizable with very low latency, written with a Node.js adaptation of the Web Audio API.",
+	"version": "0.2.1",
+	"publisher": "AidanHsiao",
+	"engines": {
+		"vscode": "^1.101.0"
+	},
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"onStartupFinished"
+	],
+	"main": "./dist/extension.js",
+	"contributes": {
+		"commands": [
+			{
+				"command": "vscode-animalese.enable",
+				"title": "vscode-animalese: Enable Animalese Sounds"
+			},
+			{
+				"command": "vscode-animalese.disable",
+				"title": "vscode-animalese: Disable Animalese Sounds"
+			},
+			{
+				"command": "vscode-animalese.toggle",
+				"title": "vscode-animalese: Toggle Animalese Sounds"
+			},
+			{
+				"command": "vscode-animalese.setVolume",
+				"title": "vscode-animalese: Set Animalese Volume"
+			},
+			{
+				"command": "vscode-animalese.setVoice",
+				"title": "vscode-animalese: Set Animalese Voice"
+			}
+		],
+		"configuration": {
+			"title": "VSCode Animalese",
+			"type": "object",
+			"properties": {
+				"vscode-animalese.volume": {
+					"type": "integer",
+					"default": 50,
+					"description": "This value dictates, in percentage, how loud the animalese sounds should be.",
+					"order": 1,
+					"minimum": 0,
+					"maximum": 100
+				},
+				"vscode-animalese.voice": {
+					"type": "string",
+					"enum": [
+						"Female Voice 1 (Sweet)",
+						"Female Voice 2 (Peppy)",
+						"Female Voice 3 (Big Sister)",
+						"Female Voice 4 (Snooty)",
+						"Male Voice 1 (Jock)",
+						"Male Voice 2 (Lazy)",
+						"Male Voice 3 (Smug)",
+						"Male Voice 4 (Cranky)"
+					],
+					"default": "Female Voice 1 (Sweet)",
+					"description": "Determines the voice that will be talking. This setting only applies to alphanumerical characters.",
+					"order": 2
+				},
+				"vscode-animalese.specialPunctuation": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Overrides the default sounds for the keys `!`, `?`, and `Enter`.",
+					"order": 3
+				},
+				"vscode-animalese.soundOverride": {
+					"type": "string",
+					"default": "",
+					"markdownDescription": "Replace **ALL** sounds with an absolute path to the given sound file.",
+					"order": 4
+				},
+				"vscode-animalese.intonation.louderUppercase": {
+					"type": "number",
+					"default": 20,
+					"description": "Indicates the percentage increase that uppercase letters will make, over lowercase letters. For example, if this value is 25, the volume of any uppercase letter will be 125%.",
+					"minimum": 0
+				},
+				"vscode-animalese.intonation.falloffTime": {
+					"type": "number",
+					"default": 0.5,
+					"description": "When a key is pressed, the audio slowly fades out over the course of the track. This value determines how many seconds it takes before the audio fully fades out.",
+					"minimum": 0
+				},
+				"vscode-animalese.intonation.pitchVariation": {
+					"type": "integer",
+					"default": 100,
+					"markdownDescription": "For any key except for vocal keys, randomly shift the pitch of the audio up or down by, at most, the amount of [cents](https://en.wikipedia.org/wiki/Cent_%28music%29) given.",
+					"minimum": 0
+				},
+				"vscode-animalese.intonation.switchToExponentialFalloff": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "If checked, the audio volume will fall off at an exponential rate instead of a linear one."
+				}
+			}
+		}
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run package",
+		"compile": "webpack",
+		"watch": "webpack --watch",
+		"package": "webpack --mode production --devtool hidden-source-map",
+		"compile-tests": "tsc -p . --outDir out",
+		"watch-tests": "tsc -p . -w --outDir out",
+		"lint": "eslint src",
+		"test": "jest"
+	},
+	"devDependencies": {
+		"@types/jest": "^29.5.14",
+		"@types/mocha": "^10.0.10",
+		"@types/node": "20.x",
+		"@types/vscode": "^1.101.0",
+		"@typescript-eslint/eslint-plugin": "^8.31.1",
+		"@typescript-eslint/parser": "^8.31.1",
+		"@vscode/test-cli": "^0.0.10",
+		"@vscode/test-electron": "^2.5.2",
+		"eslint": "^9.25.1",
+		"jest": "^29.7.0",
+		"node-loader": "^2.1.0",
+		"ts-jest": "^29.4.0",
+		"ts-loader": "^9.5.2",
+		"typescript": "^5.8.3",
+		"webpack": "^5.99.7",
+		"webpack-cli": "^6.0.1"
+	},
+	"dependencies": {
+		"node-web-audio-api": "^1.0.4"
+	},
+	"icon": "public/icon.png",
+	"galleryBanner": {
+		"color": "#e0d0b4",
+		"theme": "light"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/ESV-Sweetplum/vscode-animalese.git"
+	},
+	"homepage": "https://github.com/ESV-Sweetplum/vscode-animalese/blob/main/README.md",
+	"license": "https://github.com/ESV-Sweetplum/vscode-animalese/blob/main/LICENSE",
+	"keywords": [
+		"Animalese",
+		"Animal Crossing",
+		"Tom Nook",
+		"Isabelle",
+		"Typing Sound",
+		"Sound",
+		"Audio",
+		"Keypress Audio",
+		"Keypress Sounds",
+		"Typing Sounds"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -1,160 +1,160 @@
 {
-	"name": "vscode-animalese",
-	"displayName": "VSCode Animalese",
-	"description": "Makes animal crossing sounds whenever you type. Highly customizable with very low latency, written with a Node.js adaptation of the Web Audio API.",
-	"version": "0.2.1",
-	"publisher": "AidanHsiao",
-	"engines": {
-		"vscode": "^1.101.0"
-	},
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-		"onStartupFinished"
-	],
-	"main": "./dist/extension.js",
-	"contributes": {
-		"commands": [
-			{
-				"command": "vscode-animalese.enable",
-				"title": "vscode-animalese: Enable Animalese Sounds"
-			},
-			{
-				"command": "vscode-animalese.disable",
-				"title": "vscode-animalese: Disable Animalese Sounds"
-			},
-			{
-				"command": "vscode-animalese.toggle",
-				"title": "vscode-animalese: Toggle Animalese Sounds"
-			},
-			{
-				"command": "vscode-animalese.setVolume",
-				"title": "vscode-animalese: Set Animalese Volume"
-			},
-			{
-				"command": "vscode-animalese.setVoice",
-				"title": "vscode-animalese: Set Animalese Voice"
-			}
-		],
-		"configuration": {
-			"title": "VSCode Animalese",
-			"type": "object",
-			"properties": {
-				"vscode-animalese.volume": {
-					"type": "integer",
-					"default": 50,
-					"description": "This value dictates, in percentage, how loud the animalese sounds should be.",
-					"order": 1,
-					"minimum": 0,
-					"maximum": 100
-				},
-				"vscode-animalese.voice": {
-					"type": "string",
-					"enum": [
-						"Female Voice 1 (Sweet)",
-						"Female Voice 2 (Peppy)",
-						"Female Voice 3 (Big Sister)",
-						"Female Voice 4 (Snooty)",
-						"Male Voice 1 (Jock)",
-						"Male Voice 2 (Lazy)",
-						"Male Voice 3 (Smug)",
-						"Male Voice 4 (Cranky)"
-					],
-					"default": "Female Voice 1 (Sweet)",
-					"description": "Determines the voice that will be talking. This setting only applies to alphanumerical characters.",
-					"order": 2
-				},
-				"vscode-animalese.specialPunctuation": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "Overrides the default sounds for the keys `!`, `?`, and `Enter`.",
-					"order": 3
-				},
-				"vscode-animalese.soundOverride": {
-					"type": "string",
-					"default": "",
-					"markdownDescription": "Replace **ALL** sounds with an absolute path to the given sound file.",
-					"order": 4
-				},
-				"vscode-animalese.intonation.louderUppercase": {
-					"type": "number",
-					"default": 20,
-					"description": "Indicates the percentage increase that uppercase letters will make, over lowercase letters. For example, if this value is 25, the volume of any uppercase letter will be 125%.",
-					"minimum": 0
-				},
-				"vscode-animalese.intonation.falloffTime": {
-					"type": "number",
-					"default": 0.5,
-					"description": "When a key is pressed, the audio slowly fades out over the course of the track. This value determines how many seconds it takes before the audio fully fades out.",
-					"minimum": 0
-				},
-				"vscode-animalese.intonation.pitchVariation": {
-					"type": "integer",
-					"default": 100,
-					"markdownDescription": "For any key except for vocal keys, randomly shift the pitch of the audio up or down by, at most, the amount of [cents](https://en.wikipedia.org/wiki/Cent_%28music%29) given.",
-					"minimum": 0
-				},
-				"vscode-animalese.intonation.switchToExponentialFalloff": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "If checked, the audio volume will fall off at an exponential rate instead of a linear one."
-				}
-			}
-		}
-	},
-	"scripts": {
-		"vscode:prepublish": "npm run package",
-		"compile": "webpack",
-		"watch": "webpack --watch",
-		"package": "webpack --mode production --devtool hidden-source-map",
-		"compile-tests": "tsc -p . --outDir out",
-		"watch-tests": "tsc -p . -w --outDir out",
-		"lint": "eslint src",
-		"test": "jest"
-	},
-	"devDependencies": {
-		"@types/jest": "^29.5.14",
-		"@types/mocha": "^10.0.10",
-		"@types/node": "20.x",
-		"@types/vscode": "^1.101.0",
-		"@typescript-eslint/eslint-plugin": "^8.31.1",
-		"@typescript-eslint/parser": "^8.31.1",
-		"@vscode/test-cli": "^0.0.10",
-		"@vscode/test-electron": "^2.5.2",
-		"eslint": "^9.25.1",
-		"jest": "^29.7.0",
-		"node-loader": "^2.1.0",
-		"ts-jest": "^29.4.0",
-		"ts-loader": "^9.5.2",
-		"typescript": "^5.8.3",
-		"webpack": "^5.99.7",
-		"webpack-cli": "^6.0.1"
-	},
-	"dependencies": {
-		"node-web-audio-api": "^1.0.4"
-	},
-	"icon": "public/icon.png",
-	"galleryBanner": {
-		"color": "#e0d0b4",
-		"theme": "light"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/ESV-Sweetplum/vscode-animalese.git"
-	},
-	"homepage": "https://github.com/ESV-Sweetplum/vscode-animalese/blob/main/README.md",
-	"license": "https://github.com/ESV-Sweetplum/vscode-animalese/blob/main/LICENSE",
-	"keywords": [
-		"Animalese",
-		"Animal Crossing",
-		"Tom Nook",
-		"Isabelle",
-		"Typing Sound",
-		"Sound",
-		"Audio",
-		"Keypress Audio",
-		"Keypress Sounds",
-		"Typing Sounds"
-	]
+    "name": "vscode-animalese",
+    "displayName": "VSCode Animalese",
+    "description": "Makes animal crossing sounds whenever you type. Highly customizable with very low latency, written with a Node.js adaptation of the Web Audio API.",
+    "version": "0.2.1",
+    "publisher": "AidanHsiao",
+    "engines": {
+        "vscode": "^1.101.0"
+    },
+    "categories": [
+        "Other"
+    ],
+    "activationEvents": [
+        "onStartupFinished"
+    ],
+    "main": "./dist/extension.js",
+    "contributes": {
+        "commands": [
+            {
+                "command": "vscode-animalese.enable",
+                "title": "vscode-animalese: Enable Animalese Sounds"
+            },
+            {
+                "command": "vscode-animalese.disable",
+                "title": "vscode-animalese: Disable Animalese Sounds"
+            },
+            {
+                "command": "vscode-animalese.toggle",
+                "title": "vscode-animalese: Toggle Animalese Sounds"
+            },
+            {
+                "command": "vscode-animalese.setVolume",
+                "title": "vscode-animalese: Set Animalese Volume"
+            },
+            {
+                "command": "vscode-animalese.setVoice",
+                "title": "vscode-animalese: Set Animalese Voice"
+            }
+        ],
+        "configuration": {
+            "title": "VSCode Animalese",
+            "type": "object",
+            "properties": {
+                "vscode-animalese.volume": {
+                    "type": "integer",
+                    "default": 50,
+                    "description": "This value dictates, in percentage, how loud the animalese sounds should be.",
+                    "order": 1,
+                    "minimum": 0,
+                    "maximum": 100
+                },
+                "vscode-animalese.voice": {
+                    "type": "string",
+                    "enum": [
+                        "Female Voice 1 (Sweet)",
+                        "Female Voice 2 (Peppy)",
+                        "Female Voice 3 (Big Sister)",
+                        "Female Voice 4 (Snooty)",
+                        "Male Voice 1 (Jock)",
+                        "Male Voice 2 (Lazy)",
+                        "Male Voice 3 (Smug)",
+                        "Male Voice 4 (Cranky)"
+                    ],
+                    "default": "Female Voice 1 (Sweet)",
+                    "description": "Determines the voice that will be talking. This setting only applies to alphanumerical characters.",
+                    "order": 2
+                },
+                "vscode-animalese.specialPunctuation": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Overrides the default sounds for the keys `!`, `?`, and `Enter`.",
+                    "order": 3
+                },
+                "vscode-animalese.soundOverride": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Replace **ALL** sounds with an absolute path to the given sound file.",
+                    "order": 4
+                },
+                "vscode-animalese.intonation.louderUppercase": {
+                    "type": "number",
+                    "default": 20,
+                    "description": "Indicates the percentage increase that uppercase letters will make, over lowercase letters. For example, if this value is 25, the volume of any uppercase letter will be 125%.",
+                    "minimum": 0
+                },
+                "vscode-animalese.intonation.falloffTime": {
+                    "type": "number",
+                    "default": 0.5,
+                    "description": "When a key is pressed, the audio slowly fades out over the course of the track. This value determines how many seconds it takes before the audio fully fades out.",
+                    "minimum": 0
+                },
+                "vscode-animalese.intonation.pitchVariation": {
+                    "type": "integer",
+                    "default": 100,
+                    "markdownDescription": "For any key except for vocal keys, randomly shift the pitch of the audio up or down by, at most, the amount of [cents](https://en.wikipedia.org/wiki/Cent_%28music%29) given.",
+                    "minimum": 0
+                },
+                "vscode-animalese.intonation.switchToExponentialFalloff": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "If checked, the audio volume will fall off at an exponential rate instead of a linear one."
+                }
+            }
+        }
+    },
+    "scripts": {
+        "vscode:prepublish": "npm run package",
+        "compile": "webpack",
+        "watch": "webpack --watch",
+        "package": "webpack --mode production --devtool hidden-source-map",
+        "compile-tests": "tsc -p . --outDir out",
+        "watch-tests": "tsc -p . -w --outDir out",
+        "lint": "eslint src",
+        "test": "jest"
+    },
+    "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "20.x",
+        "@types/vscode": "^1.101.0",
+        "@typescript-eslint/eslint-plugin": "^8.31.1",
+        "@typescript-eslint/parser": "^8.31.1",
+        "@vscode/test-cli": "^0.0.10",
+        "@vscode/test-electron": "^2.5.2",
+        "eslint": "^9.25.1",
+        "jest": "^29.7.0",
+        "node-loader": "^2.1.0",
+        "ts-jest": "^29.4.0",
+        "ts-loader": "^9.5.2",
+        "typescript": "^5.8.3",
+        "webpack": "^5.99.7",
+        "webpack-cli": "^6.0.1"
+    },
+    "dependencies": {
+        "node-web-audio-api": "^1.0.4"
+    },
+    "icon": "public/icon.png",
+    "galleryBanner": {
+        "color": "#e0d0b4",
+        "theme": "light"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ESV-Sweetplum/vscode-animalese.git"
+    },
+    "homepage": "https://github.com/ESV-Sweetplum/vscode-animalese/blob/main/README.md",
+    "license": "https://github.com/ESV-Sweetplum/vscode-animalese/blob/main/LICENSE",
+    "keywords": [
+        "Animalese",
+        "Animal Crossing",
+        "Tom Nook",
+        "Isabelle",
+        "Typing Sound",
+        "Sound",
+        "Audio",
+        "Keypress Audio",
+        "Keypress Sounds",
+        "Typing Sounds"
+    ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,105 +1,107 @@
-import * as vscode from "vscode";
-import * as fs from "fs";
-import { AudioContext } from "node-web-audio-api";
-import { isMelodic } from "./isParticularType";
-import { getFilePath } from "./get/filePath";
-import { settings } from "./settings/pluginSettings";
-import { loadSettings } from "./settings/loadSettings";
-import { getToggleCommand } from "./commands/toggle";
-import { getEnableCommand } from "./commands/enable";
-import { getDisableCommand } from "./commands/disable";
-import { getSetVoiceCommand } from "./commands/setVoice";
-import { getSetVolumeCommand } from "./commands/setVolume";
-import { VOICE_LIST } from "./constants/voiceList";
-import getAudioData from "./get/audioData";
+import * as vscode from 'vscode'
+import * as fs from 'fs'
+import { AudioContext } from 'node-web-audio-api'
+import { isMelodic } from './isParticularType'
+import { getFilePath } from './get/filePath'
+import { settings } from './settings/pluginSettings'
+import { loadSettings } from './settings/loadSettings'
+import { getToggleCommand } from './commands/toggle'
+import { getEnableCommand } from './commands/enable'
+import { getDisableCommand } from './commands/disable'
+import { getSetVoiceCommand } from './commands/setVoice'
+import { getSetVolumeCommand } from './commands/setVolume'
+import { VOICE_LIST } from './constants/voiceList'
+import getAudioData from './get/audioData'
 
-export let extensionEnabled = true;
-export const setExtensionEnabled = (val: boolean) => (extensionEnabled = val);
+export let extensionEnabled = true
+export const setExtensionEnabled = (val: boolean) => (extensionEnabled = val)
 
 export function activate(context: vscode.ExtensionContext) {
-    loadSettings(true);
+	console.debug('activate')
+	loadSettings(true)
+	// test
 
-    vscode.workspace.onDidChangeConfiguration((event) => {
-        if (!event.affectsConfiguration("vscode-animalese")) return;
-        loadSettings(false); // Needed to update the `settings` variable for immediate effect.
-    });
+	vscode.workspace.onDidChangeConfiguration((event) => {
+		if (!event.affectsConfiguration('vscode-animalese')) return
+		loadSettings(false) // Needed to update the `settings` variable for immediate effect.
+	})
 
-    const commands = [
-        getToggleCommand(),
-        getEnableCommand(),
-        getDisableCommand(),
-        getSetVoiceCommand(),
-        getSetVolumeCommand(),
-    ];
+	const commands = [
+		getToggleCommand(),
+		getEnableCommand(),
+		getDisableCommand(),
+		getSetVoiceCommand(),
+		getSetVolumeCommand()
+	]
 
-    context.subscriptions.push(...commands);
+	context.subscriptions.push(...commands)
 
-    vscode.workspace.onDidChangeTextDocument((event) => {
-        if (!extensionEnabled || !event.contentChanges.length) return;
+	vscode.workspace.onDidChangeTextDocument((event) => {
+		if (!extensionEnabled || !event.contentChanges.length) return
 
-        handleKeyPress(event);
-    });
+		handleKeyPress(context, event)
+	})
 }
 
 export function deactivate() {}
 
-export async function handleKeyPress(event: vscode.TextDocumentChangeEvent) {
-    let key = event.contentChanges[0].text.replaceAll("\r", "").slice(0, 1);
-    if (/^( ){2,}$/.test(event.contentChanges[0].text)) {
-        key = "tab"; // Only if the text is 2 or more spaces.
-    }
-    if (event.contentChanges[0].rangeLength > 0) key = "backspace"; // Assume backspace is pressed, upon any text being deleted/replaced. There's not really a better way to do this.
+async function handleKeyPress(
+	context: vscode.ExtensionContext,
+	event: vscode.TextDocumentChangeEvent
+) {
+	let key = event.contentChanges[0].text.replaceAll('\r', '').slice(0, 1)
+	if (/^( ){2,}$/.test(event.contentChanges[0].text)) {
+		key = 'tab' // Only if the text is 2 or more spaces.
+	}
+	if (event.contentChanges[0].rangeLength > 0) key = 'backspace' // Assume backspace is pressed, upon any text being deleted/replaced. There's not really a better way to do this.
 
-    let filePath = getFilePath(
-        key,
-        VOICE_LIST.indexOf(settings.voice),
-        settings
-    );
+	let filePath = getFilePath(
+		context.extensionPath,
+		key,
+		VOICE_LIST.indexOf(settings.voice),
+		settings
+	)
 
-    if (!fs.existsSync(filePath)) {
-        vscode.window.showErrorMessage(
-            "The provided custom sound does not exist. Please change the soundOverride parameter to a valid path."
-        );
-        return;
-    }
+	if (!fs.existsSync(filePath)) {
+		vscode.window.showErrorMessage(
+			'The provided custom sound does not exist. Please change the soundOverride parameter to a valid path.'
+		)
+		return
+	}
 
-    const audioContext = new AudioContext();
-    const { audioBuffer, delay } = await getAudioData(filePath, audioContext);
+	const audioContext = new AudioContext()
+	const { audioBuffer, delay } = await getAudioData(filePath, audioContext)
 
-    const source = audioContext.createBufferSource();
-    source.buffer = audioBuffer;
-    source.detune.value = isMelodic(key)
-        ? 0
-        : Math.random() * settings.intonation_pitchVariation * 2 -
-          settings.intonation_pitchVariation;
+	const source = audioContext.createBufferSource()
+	source.buffer = audioBuffer
+	source.detune.value = isMelodic(key)
+		? 0
+		: Math.random() * settings.intonation_pitchVariation * 2 - settings.intonation_pitchVariation
 
-    const gainNode = audioContext.createGain();
-    let audioVolume = settings.volume;
-    if (settings.intonation_louderUppercase > 0 && /^[A-Z]$/.test(key)) {
-        audioVolume =
-            audioVolume * (1 + settings.intonation_louderUppercase / 100);
-        source.detune.value =
-            1.5 *
-            settings.intonation_pitchVariation *
-            (1 + settings.intonation_louderUppercase / 100);
-    }
+	const gainNode = audioContext.createGain()
+	let audioVolume = settings.volume
+	if (settings.intonation_louderUppercase > 0 && /^[A-Z]$/.test(key)) {
+		audioVolume = audioVolume * (1 + settings.intonation_louderUppercase / 100)
+		source.detune.value =
+			1.5 * settings.intonation_pitchVariation * (1 + settings.intonation_louderUppercase / 100)
+	}
 
-    gainNode.gain.setValueAtTime(audioVolume / 100, audioContext.currentTime);
-    if (settings.intonation_switchToExponentialFalloff) {
-        gainNode.gain.exponentialRampToValueAtTime(
-            1e-5, // Exponential function can never equal 0.
-            audioContext.currentTime + settings.intonation_falloffTime
-        );
-    } else {
-        gainNode.gain.linearRampToValueAtTime(
-            0,
-            audioContext.currentTime + settings.intonation_falloffTime
-        );
-    }
-    source.connect(gainNode);
-    gainNode.connect(audioContext.destination);
-    source.start(0, delay);
-    source.onended = (_) => {
-        audioContext.close();
-    };
+	gainNode.gain.setValueAtTime(audioVolume / 100, audioContext.currentTime)
+	if (settings.intonation_switchToExponentialFalloff) {
+		gainNode.gain.exponentialRampToValueAtTime(
+			1e-5, // Exponential function can never equal 0.
+			audioContext.currentTime + settings.intonation_falloffTime
+		)
+	} else {
+		gainNode.gain.linearRampToValueAtTime(
+			0,
+			audioContext.currentTime + settings.intonation_falloffTime
+		)
+	}
+	source.connect(gainNode)
+	gainNode.connect(audioContext.destination)
+	source.start(0, delay)
+	source.onended = (_) => {
+		audioContext.close()
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,9 +17,7 @@ export let extensionEnabled = true
 export const setExtensionEnabled = (val: boolean) => (extensionEnabled = val)
 
 export function activate(context: vscode.ExtensionContext) {
-	console.debug('activate')
 	loadSettings(true)
-	// test
 
 	vscode.workspace.onDidChangeConfiguration((event) => {
 		if (!event.affectsConfiguration('vscode-animalese')) return

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,105 +1,109 @@
-import * as vscode from 'vscode'
-import * as fs from 'fs'
-import { AudioContext } from 'node-web-audio-api'
-import { isMelodic } from './isParticularType'
-import { getFilePath } from './get/filePath'
-import { settings } from './settings/pluginSettings'
-import { loadSettings } from './settings/loadSettings'
-import { getToggleCommand } from './commands/toggle'
-import { getEnableCommand } from './commands/enable'
-import { getDisableCommand } from './commands/disable'
-import { getSetVoiceCommand } from './commands/setVoice'
-import { getSetVolumeCommand } from './commands/setVolume'
-import { VOICE_LIST } from './constants/voiceList'
-import getAudioData from './get/audioData'
+import * as vscode from "vscode";
+import * as fs from "fs";
+import { AudioContext } from "node-web-audio-api";
+import { isMelodic } from "./isParticularType";
+import { getFilePath } from "./get/filePath";
+import { settings } from "./settings/pluginSettings";
+import { loadSettings } from "./settings/loadSettings";
+import { getToggleCommand } from "./commands/toggle";
+import { getEnableCommand } from "./commands/enable";
+import { getDisableCommand } from "./commands/disable";
+import { getSetVoiceCommand } from "./commands/setVoice";
+import { getSetVolumeCommand } from "./commands/setVolume";
+import { VOICE_LIST } from "./constants/voiceList";
+import getAudioData from "./get/audioData";
 
-export let extensionEnabled = true
-export const setExtensionEnabled = (val: boolean) => (extensionEnabled = val)
+export let extensionEnabled = true;
+export const setExtensionEnabled = (val: boolean) => (extensionEnabled = val);
 
 export function activate(context: vscode.ExtensionContext) {
-	loadSettings(true)
+    loadSettings(true);
 
-	vscode.workspace.onDidChangeConfiguration((event) => {
-		if (!event.affectsConfiguration('vscode-animalese')) return
-		loadSettings(false) // Needed to update the `settings` variable for immediate effect.
-	})
+    vscode.workspace.onDidChangeConfiguration((event) => {
+        if (!event.affectsConfiguration("vscode-animalese")) return;
+        loadSettings(false); // Needed to update the `settings` variable for immediate effect.
+    });
 
-	const commands = [
-		getToggleCommand(),
-		getEnableCommand(),
-		getDisableCommand(),
-		getSetVoiceCommand(),
-		getSetVolumeCommand()
-	]
+    const commands = [
+        getToggleCommand(),
+        getEnableCommand(),
+        getDisableCommand(),
+        getSetVoiceCommand(),
+        getSetVolumeCommand(),
+    ];
 
-	context.subscriptions.push(...commands)
+    context.subscriptions.push(...commands);
 
-	vscode.workspace.onDidChangeTextDocument((event) => {
-		if (!extensionEnabled || !event.contentChanges.length) return
+    vscode.workspace.onDidChangeTextDocument((event) => {
+        if (!extensionEnabled || !event.contentChanges.length) return;
 
-		handleKeyPress(context, event)
-	})
+        handleKeyPress(context, event);
+    });
 }
 
 export function deactivate() {}
 
-async function handleKeyPress(
-	context: vscode.ExtensionContext,
-	event: vscode.TextDocumentChangeEvent
+export async function handleKeyPress(
+    context: vscode.ExtensionContext,
+    event: vscode.TextDocumentChangeEvent
 ) {
-	let key = event.contentChanges[0].text.replaceAll('\r', '').slice(0, 1)
-	if (/^( ){2,}$/.test(event.contentChanges[0].text)) {
-		key = 'tab' // Only if the text is 2 or more spaces.
-	}
-	if (event.contentChanges[0].rangeLength > 0) key = 'backspace' // Assume backspace is pressed, upon any text being deleted/replaced. There's not really a better way to do this.
+    let key = event.contentChanges[0].text.replaceAll("\r", "").slice(0, 1);
+    if (/^( ){2,}$/.test(event.contentChanges[0].text)) {
+        key = "tab"; // Only if the text is 2 or more spaces.
+    }
+    if (event.contentChanges[0].rangeLength > 0) key = "backspace"; // Assume backspace is pressed, upon any text being deleted/replaced. There's not really a better way to do this.
 
-	let filePath = getFilePath(
-		context.extensionPath,
-		key,
-		VOICE_LIST.indexOf(settings.voice),
-		settings
-	)
+    let filePath = getFilePath(
+        context.extensionPath,
+        key,
+        VOICE_LIST.indexOf(settings.voice),
+        settings
+    );
 
-	if (!fs.existsSync(filePath)) {
-		vscode.window.showErrorMessage(
-			'The provided custom sound does not exist. Please change the soundOverride parameter to a valid path.'
-		)
-		return
-	}
+    if (!fs.existsSync(filePath)) {
+        vscode.window.showErrorMessage(
+            "The provided custom sound does not exist. Please change the soundOverride parameter to a valid path."
+        );
+        return;
+    }
 
-	const audioContext = new AudioContext()
-	const { audioBuffer, delay } = await getAudioData(filePath, audioContext)
+    const audioContext = new AudioContext();
+    const { audioBuffer, delay } = await getAudioData(filePath, audioContext);
 
-	const source = audioContext.createBufferSource()
-	source.buffer = audioBuffer
-	source.detune.value = isMelodic(key)
-		? 0
-		: Math.random() * settings.intonation_pitchVariation * 2 - settings.intonation_pitchVariation
+    const source = audioContext.createBufferSource();
+    source.buffer = audioBuffer;
+    source.detune.value = isMelodic(key)
+        ? 0
+        : Math.random() * settings.intonation_pitchVariation * 2 -
+          settings.intonation_pitchVariation;
 
-	const gainNode = audioContext.createGain()
-	let audioVolume = settings.volume
-	if (settings.intonation_louderUppercase > 0 && /^[A-Z]$/.test(key)) {
-		audioVolume = audioVolume * (1 + settings.intonation_louderUppercase / 100)
-		source.detune.value =
-			1.5 * settings.intonation_pitchVariation * (1 + settings.intonation_louderUppercase / 100)
-	}
+    const gainNode = audioContext.createGain();
+    let audioVolume = settings.volume;
+    if (settings.intonation_louderUppercase > 0 && /^[A-Z]$/.test(key)) {
+        audioVolume =
+            audioVolume * (1 + settings.intonation_louderUppercase / 100);
+        source.detune.value =
+            1.5 *
+            settings.intonation_pitchVariation *
+            (1 + settings.intonation_louderUppercase / 100);
+    }
 
-	gainNode.gain.setValueAtTime(audioVolume / 100, audioContext.currentTime)
-	if (settings.intonation_switchToExponentialFalloff) {
-		gainNode.gain.exponentialRampToValueAtTime(
-			1e-5, // Exponential function can never equal 0.
-			audioContext.currentTime + settings.intonation_falloffTime
-		)
-	} else {
-		gainNode.gain.linearRampToValueAtTime(
-			0,
-			audioContext.currentTime + settings.intonation_falloffTime
-		)
-	}
-	source.connect(gainNode)
-	gainNode.connect(audioContext.destination)
-	source.start(0, delay)
-	source.onended = (_) => {
-		audioContext.close()
-	}
+    gainNode.gain.setValueAtTime(audioVolume / 100, audioContext.currentTime);
+    if (settings.intonation_switchToExponentialFalloff) {
+        gainNode.gain.exponentialRampToValueAtTime(
+            1e-5, // Exponential function can never equal 0.
+            audioContext.currentTime + settings.intonation_falloffTime
+        );
+    } else {
+        gainNode.gain.linearRampToValueAtTime(
+            0,
+            audioContext.currentTime + settings.intonation_falloffTime
+        );
+    }
+    source.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+    source.start(0, delay);
+    source.onended = (_) => {
+        audioContext.close();
+    };
 }

--- a/src/get/filePath.ts
+++ b/src/get/filePath.ts
@@ -1,10 +1,10 @@
-import path from 'path'
-import { isAlphabetical, isHarmonic, isSymbolic } from '../isParticularType'
-import { HARMONIC_CHARACTERS } from '../constants/charTypes'
-import { settings } from '../settings/pluginSettings'
-import { VOICE_LIST } from '../constants/voiceList'
+import path from "path";
+import { isAlphabetical, isHarmonic, isSymbolic } from "../isParticularType";
+import { HARMONIC_CHARACTERS } from "../constants/charTypes";
+import { settings } from "../settings/pluginSettings";
+import { VOICE_LIST } from "../constants/voiceList";
 
-const PATH_CACHE: Map<string, string> = new Map()
+const PATH_CACHE: Map<string, string> = new Map();
 
 /**
  * ### Gets the corresponding audio path to the given input.
@@ -14,135 +14,131 @@ const PATH_CACHE: Map<string, string> = new Map()
  * @returns {string} The path to the file which should be played.
  */
 export function getFilePath(
-	extensionPath: string = __dirname,
-	key: string,
-	vocalIndex: number,
-	pluginSettings: typeof settings
+    extensionPath: string,
+    key: string,
+    vocalIndex: number,
+    pluginSettings: typeof settings
 ): string {
-	if (pluginSettings.soundOverride) return pluginSettings.soundOverride // Reminder that soundOverride is an absolute path to the desired sound.
+    if (pluginSettings.soundOverride) return pluginSettings.soundOverride; // Reminder that soundOverride is an absolute path to the desired sound.
 
-	let filePath = ''
+    let filePath = "";
 
-	const cachedPath = PATH_CACHE.get(
-		`${key}${VOICE_LIST.indexOf(settings.voice)}${+settings.specialPunctuation}`
-	)
-	if (cachedPath && !settings.soundOverride) {
-		return cachedPath
-	}
+    const cachedPath = PATH_CACHE.get(
+        `${key}${VOICE_LIST.indexOf(
+            settings.voice
+        )}${+settings.specialPunctuation}`
+    );
+    if (cachedPath && !settings.soundOverride) {
+        return cachedPath;
+    }
 
-	// Note: some funky math tricks were used to greatly simplify converting vocalIndex (0-7) to male/female voices 1-4. Here, `vocalIndex = 0-3` represents female voices 1-4, while `vocalIndex = 4-7` represents male voices 1-4.
+    // Note: some funky math tricks were used to greatly simplify converting vocalIndex (0-7) to male/female voices 1-4. Here, `vocalIndex = 0-3` represents female voices 1-4, while `vocalIndex = 4-7` represents male voices 1-4.
+    const animalesePath = path.join(extensionPath, "audio", "animalese",
+        vocalIndex <= 3 ? "female" : "male",
+        `voice_${(vocalIndex % 4) + 1}`,
+    );
+    const vocalsPath = path.join(extensionPath, "audio", "vocals",
+        vocalIndex <= 3 ? "female" : "male",
+        `voice_${(vocalIndex % 4) + 1}`,
+    );
+    const sfxPath = path.join(extensionPath, "audio", "sfx");
 
-	const animalesePath = path.join(
-		extensionPath,
-		'audio',
-		'animalese',
-		vocalIndex <= 3 ? 'female' : 'male',
-		`voice_${(vocalIndex % 4) + 1}`
-	)
+    switch (true) {
+        case isAlphabetical(key): {
+            filePath = path.join(animalesePath, `${key}.mp3`);
+            break;
+        }
+        case isHarmonic(key): {
+            filePath = path.join(vocalsPath, `${HARMONIC_CHARACTERS.indexOf(key)}.mp3`);
+            break;
+        }
+        case key === "!" || key === "?" || key.includes("\n"): {
+            if (pluginSettings.specialPunctuation) {
+                const noise = { "!": "Gwah", "?": "Deska", "\n": "OK" };
+                filePath = path.join(animalesePath, `${noise[key as keyof typeof noise]}.mp3`);
+                break;
+            }
+        }
+        case isSymbolic(key): {
+            filePath = path.join(sfxPath, `${symbolToName(key) ?? "default"}.mp3`);
+            break;
+        }
+        case ["tab", "backspace"].includes(key): {
+            filePath = path.join(sfxPath, `${key}.mp3`);
+            break;
+        }
+        default: {
+            filePath = path.join(sfxPath, `default.mp3`);
+            break;
+        }
+    }
+    PATH_CACHE.set(
+        `${key}${settings.voice}${+settings.specialPunctuation}`,
+        filePath
+    );
 
-	const vocalsPath = path.join(
-		extensionPath,
-		'audio',
-		'vocals',
-		vocalIndex <= 3 ? 'female' : 'male',
-		`voice_${(vocalIndex % 4) + 1}`
-	)
-
-	const sfxPath = path.join(extensionPath, 'audio', 'sfx')
-
-	switch (true) {
-		case isAlphabetical(key): {
-			filePath = path.join(animalesePath, `${key}.mp3`)
-			break
-		}
-		case isHarmonic(key): {
-			filePath = path.join(vocalsPath, `${HARMONIC_CHARACTERS.indexOf(key)}.mp3`)
-			break
-		}
-		case key === '!' || key === '?' || key.includes('\n'): {
-			if (pluginSettings.specialPunctuation) {
-				const noise = { '!': 'Gwah', '?': 'Deska', '\n': 'OK' }
-				filePath = path.join(animalesePath, `${noise[key as keyof typeof noise]}.mp3`)
-				break
-			}
-		}
-		case isSymbolic(key): {
-			filePath = path.join(sfxPath, `${symbolToName(key) ?? 'default'}.mp3`)
-			break
-		}
-		case ['tab', 'backspace'].includes(key): {
-			filePath = path.join(sfxPath, `${key}.mp3`)
-			break
-		}
-		default: {
-			filePath = path.join(sfxPath, 'default.mp3')
-			break
-		}
-	}
-	PATH_CACHE.set(`${key}${settings.voice}${+settings.specialPunctuation}`, filePath)
-
-	return filePath
+    return filePath;
 }
 
 export function symbolToName(sym: string) {
-	switch (sym) {
-		case '~': {
-			return 'tilde'
-		}
-		case '!': {
-			return 'exclamation'
-		}
-		case '@': {
-			return 'at'
-		}
-		case '#': {
-			return 'pound'
-		}
-		case '$': {
-			return 'dollar'
-		}
-		case '%': {
-			return 'percent'
-		}
-		case '^': {
-			return 'caret'
-		}
-		case '&': {
-			return 'ampersand'
-		}
-		case '*': {
-			return 'asterisk'
-		}
-		case '(': {
-			return 'parenthesis_open'
-		}
-		case ')': {
-			return 'parenthesis_closed'
-		}
-		case '{': {
-			return 'brace_open'
-		}
-		case '}': {
-			return 'brace_closed'
-		}
-		case '[': {
-			return 'bracket_open'
-		}
-		case ']': {
-			return 'bracket_closed'
-		}
-		case '?': {
-			return 'question'
-		}
-		case '\n': {
-			return 'enter'
-		}
-		case '/': {
-			return 'slash_forward'
-		}
-		case '\\': {
-			return 'slash_back'
-		}
-	}
-	return null
+    switch (sym) {
+        case "~": {
+            return "tilde";
+        }
+        case "!": {
+            return "exclamation";
+        }
+        case "@": {
+            return "at";
+        }
+        case "#": {
+            return "pound";
+        }
+        case "$": {
+            return "dollar";
+        }
+        case "%": {
+            return "percent";
+        }
+        case "^": {
+            return "caret";
+        }
+        case "&": {
+            return "ampersand";
+        }
+        case "*": {
+            return "asterisk";
+        }
+        case "(": {
+            return "parenthesis_open";
+        }
+        case ")": {
+            return "parenthesis_closed";
+        }
+        case "{": {
+            return "brace_open";
+        }
+        case "}": {
+            return "brace_closed";
+        }
+        case "[": {
+            return "bracket_open";
+        }
+        case "]": {
+            return "bracket_closed";
+        }
+        case "?": {
+            return "question";
+        }
+        case "\n": {
+            return "enter";
+        }
+        case "/": {
+            return "slash_forward";
+        }
+        case "\\": {
+            return "slash_back";
+        }
+    }
+    return null;
 }

--- a/src/get/filePath.ts
+++ b/src/get/filePath.ts
@@ -1,10 +1,10 @@
-import path from "path";
-import { isAlphabetical, isHarmonic, isSymbolic } from "../isParticularType";
-import { HARMONIC_CHARACTERS } from "../constants/charTypes";
-import { settings } from "../settings/pluginSettings";
-import { VOICE_LIST } from "../constants/voiceList";
+import path from 'path'
+import { isAlphabetical, isHarmonic, isSymbolic } from '../isParticularType'
+import { HARMONIC_CHARACTERS } from '../constants/charTypes'
+import { settings } from '../settings/pluginSettings'
+import { VOICE_LIST } from '../constants/voiceList'
 
-const PATH_CACHE: Map<string, string> = new Map();
+const PATH_CACHE: Map<string, string> = new Map()
 
 /**
  * ### Gets the corresponding audio path to the given input.
@@ -14,145 +14,135 @@ const PATH_CACHE: Map<string, string> = new Map();
  * @returns {string} The path to the file which should be played.
  */
 export function getFilePath(
-    key: string,
-    vocalIndex: number,
-    pluginSettings: typeof settings
+	extensionPath: string = __dirname,
+	key: string,
+	vocalIndex: number,
+	pluginSettings: typeof settings
 ): string {
-    if (pluginSettings.soundOverride) return pluginSettings.soundOverride; // Reminder that soundOverride is an absolute path to the desired sound.
+	if (pluginSettings.soundOverride) return pluginSettings.soundOverride // Reminder that soundOverride is an absolute path to the desired sound.
 
-    let filePath = "";
+	let filePath = ''
 
-    const cachedPath = PATH_CACHE.get(
-        `${key}${VOICE_LIST.indexOf(
-            settings.voice
-        )}${+settings.specialPunctuation}`
-    );
-    if (cachedPath && !settings.soundOverride) {
-        return cachedPath;
-    }
+	const cachedPath = PATH_CACHE.get(
+		`${key}${VOICE_LIST.indexOf(settings.voice)}${+settings.specialPunctuation}`
+	)
+	if (cachedPath && !settings.soundOverride) {
+		return cachedPath
+	}
 
-    const slash = process.platform === "win32" ? "\\" : "/"
+	// Note: some funky math tricks were used to greatly simplify converting vocalIndex (0-7) to male/female voices 1-4. Here, `vocalIndex = 0-3` represents female voices 1-4, while `vocalIndex = 4-7` represents male voices 1-4.
 
-    // Note: some funky math tricks were used to greatly simplify converting vocalIndex (0-7) to male/female voices 1-4. Here, `vocalIndex = 0-3` represents female voices 1-4, while `vocalIndex = 4-7` represents male voices 1-4.
+	const animalesePath = path.join(
+		extensionPath,
+		'audio',
+		'animalese',
+		vocalIndex <= 3 ? 'female' : 'male',
+		`voice_${(vocalIndex % 4) + 1}`
+	)
 
-    switch (true) {
-        case isAlphabetical(key): {
-            filePath = path.join(
-                __dirname,
-                `..${slash}audio${slash}animalese${slash}${
-                    vocalIndex <= 3 ? "female" : "male"
-                }${slash}voice_${(vocalIndex % 4) + 1}${slash}${key}.mp3`
-            );
-            break;
-        }
-        case isHarmonic(key): {
-            filePath = path.join(
-                __dirname,
-                `..${slash}audio${slash}vocals${slash}${
-                    vocalIndex <= 3 ? "female" : "male"
-                }${slash}voice_${(vocalIndex % 4) + 1}${slash}${HARMONIC_CHARACTERS.indexOf(
-                    key
-                )}.mp3`
-            );
-            break;
-        }
-        case key === "!" || key === "?" || key.includes("\n"): {
-            if (pluginSettings.specialPunctuation) {
-                const noise = { "!": "Gwah", "?": "Deska", "\n": "OK" };
-                filePath = path.join(
-                    __dirname,
-                    `..${slash}audio${slash}animalese${slash}${
-                        vocalIndex <= 3 ? "female" : "male"
-                    }${slash}voice_${(vocalIndex % 4) + 1}${slash}${
-                        noise[key as keyof typeof noise]
-                    }.mp3`
-                );
-                break;
-            }
-        }
-        case isSymbolic(key): {
-            filePath = path.join(
-                __dirname,
-                `..${slash}audio${slash}sfx${slash}${symbolToName(key) ?? "default"}.mp3`
-            );
-            break;
-        }
-        case ["tab", "backspace"].includes(key): {
-            filePath = path.join(__dirname, `..${slash}audio${slash}sfx${slash}${key}.mp3`);
-            break;
-        }
-        default: {
-            filePath = path.join(__dirname, `..${slash}audio${slash}sfx${slash}default.mp3`);
-            break;
-        }
-    }
-    PATH_CACHE.set(
-        `${key}${settings.voice}${+settings.specialPunctuation}`,
-        filePath
-    );
+	const vocalsPath = path.join(
+		extensionPath,
+		'audio',
+		'vocals',
+		vocalIndex <= 3 ? 'female' : 'male',
+		`voice_${(vocalIndex % 4) + 1}`
+	)
 
-    return filePath;
+	const sfxPath = path.join(extensionPath, 'audio', 'sfx')
+
+	switch (true) {
+		case isAlphabetical(key): {
+			filePath = path.join(animalesePath, `${key}.mp3`)
+			break
+		}
+		case isHarmonic(key): {
+			filePath = path.join(vocalsPath, `${HARMONIC_CHARACTERS.indexOf(key)}.mp3`)
+			break
+		}
+		case key === '!' || key === '?' || key.includes('\n'): {
+			if (pluginSettings.specialPunctuation) {
+				const noise = { '!': 'Gwah', '?': 'Deska', '\n': 'OK' }
+				filePath = path.join(animalesePath, `${noise[key as keyof typeof noise]}.mp3`)
+				break
+			}
+		}
+		case isSymbolic(key): {
+			filePath = path.join(sfxPath, `${symbolToName(key) ?? 'default'}.mp3`)
+			break
+		}
+		case ['tab', 'backspace'].includes(key): {
+			filePath = path.join(sfxPath, `${key}.mp3`)
+			break
+		}
+		default: {
+			filePath = path.join(sfxPath, 'default.mp3')
+			break
+		}
+	}
+	PATH_CACHE.set(`${key}${settings.voice}${+settings.specialPunctuation}`, filePath)
+
+	return filePath
 }
 
 export function symbolToName(sym: string) {
-    switch (sym) {
-        case "~": {
-            return "tilde";
-        }
-        case "!": {
-            return "exclamation";
-        }
-        case "@": {
-            return "at";
-        }
-        case "#": {
-            return "pound";
-        }
-        case "$": {
-            return "dollar";
-        }
-        case "%": {
-            return "percent";
-        }
-        case "^": {
-            return "caret";
-        }
-        case "&": {
-            return "ampersand";
-        }
-        case "*": {
-            return "asterisk";
-        }
-        case "(": {
-            return "parenthesis_open";
-        }
-        case ")": {
-            return "parenthesis_closed";
-        }
-        case "{": {
-            return "brace_open";
-        }
-        case "}": {
-            return "brace_closed";
-        }
-        case "[": {
-            return "bracket_open";
-        }
-        case "]": {
-            return "bracket_closed";
-        }
-        case "?": {
-            return "question";
-        }
-        case "\n": {
-            return "enter";
-        }
-        case "/": {
-            return "slash_forward";
-        }
-        case "\\": {
-            return "slash_back";
-        }
-    }
-    return null;
+	switch (sym) {
+		case '~': {
+			return 'tilde'
+		}
+		case '!': {
+			return 'exclamation'
+		}
+		case '@': {
+			return 'at'
+		}
+		case '#': {
+			return 'pound'
+		}
+		case '$': {
+			return 'dollar'
+		}
+		case '%': {
+			return 'percent'
+		}
+		case '^': {
+			return 'caret'
+		}
+		case '&': {
+			return 'ampersand'
+		}
+		case '*': {
+			return 'asterisk'
+		}
+		case '(': {
+			return 'parenthesis_open'
+		}
+		case ')': {
+			return 'parenthesis_closed'
+		}
+		case '{': {
+			return 'brace_open'
+		}
+		case '}': {
+			return 'brace_closed'
+		}
+		case '[': {
+			return 'bracket_open'
+		}
+		case ']': {
+			return 'bracket_closed'
+		}
+		case '?': {
+			return 'question'
+		}
+		case '\n': {
+			return 'enter'
+		}
+		case '/': {
+			return 'slash_forward'
+		}
+		case '\\': {
+			return 'slash_back'
+		}
+	}
+	return null
 }


### PR DESCRIPTION
The working directory of vscode extensions can change based on platform, so this PR uses `extensionPath` provided by the extension context along with `path.join()` to construct platform-agnostic file paths for the audio.