### PR TITLE
Add Korean support (and base structure for other language supports)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@
 -   `vscode-animalese.soundOverride` (absolute path): Replace **_ALL_** sounds produced by `vscode-animalese` with a sound of your choice. Supports `.mp3`, `.wav`, `.aac`, and `.ogg`.
 -   `vscode-animalese.onlySFX` (boolean): If set to true, only sound effects (non-vocal sounds) will be played when typing. Alphabetical characters will use a default SFX sound instead of animalese voices.
 -   `vscode-animalese.harmonicSFX` (boolean): If set to true, sound effects will have harmonic overtones added to them for a richer, more musical sound. Harmonic characters will use the default sound when this is enabled.
+-   `vscode-animalese.languageSupports` (string array): Enable language-specific input support. Add `"korean"` to enable Korean (Hangul) character mapping. Currently supported values: `"korean"`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "vscode-animalese",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-animalese",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "license": "https://github.com/ESV-Sweetplum/vscode-animalese/blob/main/LICENSE",
             "dependencies": {
+                "hangul-js": "^0.2.6",
                 "node-web-audio-api": "^1.0.4"
             },
             "devDependencies": {
@@ -3995,6 +3996,12 @@
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/hangul-js": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/hangul-js/-/hangul-js-0.2.6.tgz",
+            "integrity": "sha512-48axU8LgjCD30FEs66Xc04/8knxMwCMQw0f67l67rlttW7VXT3qRJgQeHmhiuGwWXGvSbk6YM0fhQlcjE1JFQA==",
             "license": "MIT"
         },
         "node_modules/has-flag": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
                 "command": "vscode-animalese.setVoice",
                 "title": "vscode-animalese: Set Animalese Voice"
             },
-                     {
+            {
                 "command": "vscode-animalese.toggleSFX",
                 "title": "vscode-animalese: Toggle Only Animalese SFX"
             },
@@ -107,7 +107,7 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "If checked, the audio volume will fall off at an exponential rate instead of a linear one."
-                }, 
+                },
                 "vscode-animalese.onlySFX": {
                     "type": "boolean",
                     "default": false,
@@ -117,6 +117,16 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "If checked, sound effects will have harmonic overtones added to them for a richer sound."
+                },
+                "vscode-animalese.languageSupports": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["korean"]
+                    },
+                    "default": [],
+                    "markdownDescription": "Enable language-specific input support. Add `\"korean\"` to enable Korean (Hangul) character mapping. Currently supported: `korean`.",
+                    "order": 5
                 }
             }
         }
@@ -150,6 +160,7 @@
         "webpack-cli": "^6.0.1"
     },
     "dependencies": {
+        "hangul-js": "^0.2.6",
         "node-web-audio-api": "^1.0.4"
     },
     "icon": "public/icon.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { getToggleSFXCommand } from './commands/toggleSFX';
 import { getToggleHarmonicSFXCommand } from './commands/toggleHarmonicSFX';
 import { VOICE_LIST } from './constants/voiceList';
 import getAudioData from './get/audioData';
+import { translate } from './languages/translate';
 
 export let extensionEnabled = true;
 export const setExtensionEnabled = (val: boolean) => (extensionEnabled = val);
@@ -51,11 +52,11 @@ export async function handleKeyPress(
     context: vscode.ExtensionContext,
     event: vscode.TextDocumentChangeEvent
 ) {
-    let key = event.contentChanges[0].text.replaceAll('\r', '').slice(0, 1);
-    if (/^( ){2,}$/.test(event.contentChanges[0].text)) {
-        key = 'tab'; // Only if the text is 2 or more spaces.
+    const { key, playAudio } = translate(event.contentChanges[0]);
+
+    if (!playAudio) {
+        return;
     }
-    if (event.contentChanges[0].rangeLength > 0) key = 'backspace'; // Assume backspace is pressed, upon any text being deleted/replaced. There's not really a better way to do this.
 
     let filePath = getFilePath(
         context.extensionPath,

--- a/src/languages/korean.ts
+++ b/src/languages/korean.ts
@@ -1,0 +1,83 @@
+import { TextDocumentContentChangeEvent } from 'vscode';
+import { isHangul, disassemble } from 'hangul-js';
+const jamoToAlphabet: Record<string, string> = {
+    // consonants
+    "ㄱ": "g",
+    "ㄲ": "k",
+    "ㄴ": "n",
+    "ㄷ": "d",
+    "ㄸ": "t",
+    "ㄹ": "r",
+    "ㅁ": "m",
+    "ㅂ": "b",
+    "ㅃ": "p",
+    "ㅅ": "s",
+    "ㅆ": "s",
+    "ㅇ": "n",
+    "ㅈ": "j",
+    "ㅉ": "j",
+    "ㅊ": "c",
+    "ㅋ": "k",
+    "ㅌ": "t",
+    "ㅍ": "p",
+    "ㅎ": "h",
+
+    // vowels
+    "ㅏ": "a",
+    "ㅐ": "i",
+    "ㅑ": "n",
+    "ㅒ": "i",
+    "ㅓ": "o",
+    "ㅔ": "i",
+    "ㅕ": "y",
+    "ㅖ": "y",
+    "ㅗ": "o",
+    "ㅛ": "y",
+    "ㅜ": "u",
+    "ㅠ": "u",
+    "ㅡ": "u",
+    "ㅣ": "e",
+};
+
+let lastEvent: TextDocumentContentChangeEvent;
+export function translateFromKorean(event: TextDocumentContentChangeEvent): { key: string, playAudio: boolean } {
+    try {
+        const key = event.text.replaceAll('\r', '').slice(0, 1);
+        if (isHangul(key) || !!jamoToAlphabet[key]) {
+            // "Syllable completion" event is fired when typing Korean. Ignore that
+            if (lastEvent && lastEvent.rangeOffset === event.rangeOffset && lastEvent.text === event.text) {
+                return {
+                    key: "",
+                    playAudio: false
+                };
+            }
+
+            const disassembled = disassemble(key);
+            const lastDisassembled = lastEvent && lastEvent.rangeOffset === event.rangeOffset ? disassemble(lastEvent.text.replaceAll('\r', '').slice(0, 1)) : [];
+
+            if (disassembled.length < lastDisassembled.length) {
+                return {
+                    key: "backspace",
+                    playAudio: true
+                };
+            }
+
+            if (disassembled.length === 0) {
+                return {
+                    key: "tab",
+                    playAudio: true
+                };
+            }
+
+            const lastJamo = disassembled[disassembled.length - 1];
+            return {
+                key: jamoToAlphabet[lastJamo] ?? lastJamo,
+                playAudio: true
+            };
+        }
+
+        throw new Error("Unsupported character");
+    } finally {
+        lastEvent = event;
+    }
+}

--- a/src/languages/translate.ts
+++ b/src/languages/translate.ts
@@ -1,0 +1,22 @@
+import { TextDocumentContentChangeEvent } from 'vscode';
+import { settings } from '../settings/pluginSettings';
+import { translateFromKorean } from './korean';
+
+export function translate(event: TextDocumentContentChangeEvent): { key: string, playAudio: boolean } {
+    try {
+        if (settings.languageSupports.includes("korean")) {
+            return translateFromKorean(event);
+        }
+    } catch {}
+
+    let key = event.text.replaceAll('\r', '').slice(0, 1);
+    if (/^( ){2,}$/.test(event.text)) {
+        key = 'tab'; // Only if the text is 2 or more spaces.
+    }
+    if (event.rangeLength > 0 && event.text === '') key = 'backspace'; // Assume backspace is pressed, upon any text being deleted/replaced. There's not really a better way to do this.
+
+    return {
+        key: key,
+        playAudio: true
+    };
+}

--- a/src/settings/pluginSettings.ts
+++ b/src/settings/pluginSettings.ts
@@ -9,6 +9,7 @@ export const settings = {
     intonation_louderUppercase: 20,
     specialPunctuation: false,
     soundOverride: '',
+    languageSupports: [] as string[]
 };
 
 export const DEFAULT_SETTINGS = structuredClone(settings); // Necessary to create a deep clone, so this object isn't modified when the original `settings` object is changed.


### PR DESCRIPTION
- Added `languageSupports` config for additional language supports (currently only supports `"korean"`)
- Introduced base structure for language specific parsers
- Added Korean(Hangul) typing support 
  - Infer proper roman character mapping from typed Korean syllables